### PR TITLE
serrano-common: ueventd: Change radio0 permissions to 0644

### DIFF
--- a/rootdir/ueventd.qcom.rc
+++ b/rootdir/ueventd.qcom.rc
@@ -54,7 +54,7 @@ subsystem msm_camera
 /dev/smd6                 0660   system     system
 /dev/smd7                 0660   bluetooth  bluetooth
 /dev/smd11                0660   radio      radio
-/dev/radio0               0640   system     system
+/dev/radio0               0644   system     system
 /dev/rfcomm0              0660   bluetooth  bluetooth
 /dev/gss                  0660   gps        gps
 /dev/smdcntl0             0640   radio      radio


### PR DESCRIPTION
Since we no longer run FM2 app as system app, we need to change
permissions on /dev/radio0 to avoid failure reading the node when
the FM2 app is run as a platform app.

Change-Id: I172444c2cd08e0113ce07bc4dd629b7bd7c715bb